### PR TITLE
Fix Homebrew Cask URL

### DIFF
--- a/templates/macros/version.html
+++ b/templates/macros/version.html
@@ -5,7 +5,7 @@
   Download MacDown<br>
   <span class="sub">Version {{ release.version }}, {{ release.length|volumize }}</span>
   </a>
-  <p class="download-alt">…or with <a href="https://brew.sh/">Homebrew Cask</a>: <code>brew cask install macdown</code>.</p>
+  <p class="download-alt">…or with <a href="https://github.com/Homebrew/homebrew-cask">Homebrew Cask</a>: <code>brew cask install macdown</code>.</p>
 </div>
 {% endif %}
 {% endmacro %}

--- a/templates/macros/version.html
+++ b/templates/macros/version.html
@@ -5,7 +5,7 @@
   Download MacDown<br>
   <span class="sub">Version {{ release.version }}, {{ release.length|volumize }}</span>
   </a>
-  <p class="download-alt">…or with <a href="http://caskroom.io">Homebrew Cask</a>: <code>brew cask install macdown</code>.</p>
+  <p class="download-alt">…or with <a href="https://brew.sh/">Homebrew Cask</a>: <code>brew cask install macdown</code>.</p>
 </div>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
http://caskroom.io/ is not managed by Homebrew Cask.