### PR TITLE
Use Requests instead of "urllib.request"

### DIFF
--- a/packages/lektor-macdown/setup.py
+++ b/packages/lektor-macdown/setup.py
@@ -4,7 +4,7 @@ setup(
     name='lektor-macdown',
     version='0.1',
     packages=find_packages(),
-    install_requires=['markupsafe', 'six'],
+    install_requires=['markupsafe', 'six', 'requests'],
     entry_points={
         'lektor.plugins': [
             'macdown = lektor_macdown:MacDownPlugin',


### PR DESCRIPTION
`urllib` is intended for low-level operations, which breaks on Python 3 that came with Xcode. Apple regards it as intended behavior and refuses to fix it.

Fixes #17.